### PR TITLE
Update to 3.1.4 and build with OpenSSL 3 [skip ci]

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,9 +1,3 @@
 # the conda-build parameters to use for disabling --skip-existing
 build_parameters:
   - ""
-
-channels:
-  staging_openssl3: openssl3
-
-aggregate_branch: openssl3_builds
-aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,8 @@
 build_parameters:
   - ""
 
+channels:
+  staging_openssl3: openssl3
+
+aggregate_branch: openssl3_builds
+aggregate_check: false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ruby" %}
-{% set version = "3.1.2" %}
+{% set version = "3.1.4" %}
 {% set major_minor = '.'.join(version.split('.')[0:2]) %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://cache.ruby-lang.org/pub/ruby/{{ major_minor }}/ruby-{{ version }}.tar.gz
-  sha256: 61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e
+  sha256: a3d55879a0dfab1d7141fdf10d22a07dbf8e5cdc4415da1bde06127d5cc3c7b6
   patches:
     # Patches/work-arounds for passing make check
     - disable-backtrace-with-lines.patch
@@ -16,7 +16,7 @@ source:
     - 0001-Dont-t-add-SDKROOT-to-vals.patch
 
 build:
-  number: 1
+  number: 2
   track_features:
     - rb{{ major_minor | replace(".", "") }}
   run_exports:
@@ -43,13 +43,14 @@ requirements:
     - gmp         # [unix]
     - libffi 3.4
     - ncurses     # [unix]
-    - openssl
+    - openssl {{ openssl }}
     - readline    # [unix]
     - yaml        # [unix]
     - zlib
   run:
     - gettext     # [osx]
     - libffi >=3.4,<3.5
+    - openssl 3.*
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - 0001-Dont-t-add-SDKROOT-to-vals.patch
 
 build:
-  number: 2
+  number: 0
   track_features:
     - rb{{ major_minor | replace(".", "") }}
   run_exports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -84,7 +84,7 @@ about:
     A dynamic, open source programming language with a focus on simplicity and productivity.
     It has an elegant syntax that is natural to read and easy to write.
   doc_url: https://www.ruby-lang.org/en/documentation/
-  dev_url: https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/
+  dev_url: https://github.com/ruby/ruby
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Update to 3.1.4 and build with OpenSSL 3.

3.1 seems to be compatible with OpenSSL 3. 3.2 is officially supported. I looked in Fedora and they don't have any OpenSSL 3 patches even if they are using OpenSSL 3: https://src.fedoraproject.org/rpms/ruby/tree/f37.